### PR TITLE
fix: remove redundant parentheticals from reason labels

### DIFF
--- a/custom_components/home_rules/rules.py
+++ b/custom_components/home_rules/rules.py
@@ -177,19 +177,15 @@ def explain(config: RuleParameters, home: HomeInput, state: CachedState) -> str:
         if home.auto:
             return "Auto idle"
         if state.last is HomeOutput.TIMER and not home.timer:
-            return "Timer cleared (reset)"
+            return "Timer expired"
         return "No change"
 
     if not home.have_solar or home.grid_usage > 0:
         if home.auto:
             if reason := _activation_reason(config, home):
                 return reason
-            return (
-                "Grid usage tolerated"
-                if (state.tolerated + 1) < config.grid_usage_delay
-                else "Grid usage too high (turn off)"
-            )
-        return "Manual mode (start timer)" if not home.timer else "No change"
+            return "Grid usage tolerated" if (state.tolerated + 1) < config.grid_usage_delay else "Grid usage too high"
+        return "Manual" if not home.timer else "No change"
 
     if home.auto and (reason := _activation_reason(config, home)):
         return reason

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.1.2"
+version = "1.1.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Remove action hints that duplicate the mode value in decision labels:

| Before | After | Decision sensor |
|---|---|---|
| `Manual mode (start timer)` | `Manual` | `Timer - Manual` |
| `Timer cleared (reset)` | `Timer expired` | `Reset - Timer expired` |
| `Grid usage too high (turn off)` | `Grid usage too high` | `Off - Grid usage too high` |

The parentheticals were redundant because the mode value (left of `-`) already conveys the action. Now each reason explains *why* without restating *what*.

Adds 7 `explain()` tests covering the cleaned labels.

Closes #17
Supersedes #18