### PR TITLE
feat: configurable threshold values via number entities

### DIFF
--- a/custom_components/home_rules/config_flow.py
+++ b/custom_components/home_rules/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.selector import SelectOptionDict
 from . import const as c
 
 _HOME_RULES_PREFIXES = tuple(
-    f"{platform}.{c.DOMAIN}_" for platform in ("switch", "select", "sensor", "binary_sensor", "button")
+    f"{platform}.{c.DOMAIN}_" for platform in ("switch", "select", "sensor", "binary_sensor", "button", "number")
 )
 _VALID_POWER_UNITS = {"", "w", "kw", "mw", "watt", "watts", "kilowatt", "kilowatts"}
 _SENSOR_KEYS = {

--- a/custom_components/home_rules/const.py
+++ b/custom_components/home_rules/const.py
@@ -14,7 +14,14 @@ class ControlMode(StrEnum):
     AGGRESSIVE = "Aggressive"
 
 
-PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.SELECT, Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
+PLATFORMS: list[Platform] = [
+    Platform.SWITCH,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+]
 
 CONF_CLIMATE_ENTITY_ID = "climate_entity_id"
 CONF_TIMER_ENTITY_ID = "timer_entity_id"

--- a/custom_components/home_rules/entities.py
+++ b/custom_components/home_rules/entities.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorEntityDescription
 from homeassistant.components.button import ButtonEntity
+from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription
 from homeassistant.components.switch import SwitchEntity
@@ -14,7 +15,20 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, ControlMode
+from .const import (
+    CONF_GENERATION_COOL_THRESHOLD,
+    CONF_GENERATION_DRY_THRESHOLD,
+    CONF_HUMIDITY_THRESHOLD,
+    CONF_TEMPERATURE_COOL,
+    CONF_TEMPERATURE_THRESHOLD,
+    DEFAULT_GENERATION_COOL_THRESHOLD,
+    DEFAULT_GENERATION_DRY_THRESHOLD,
+    DEFAULT_HUMIDITY_THRESHOLD,
+    DEFAULT_TEMPERATURE_COOL,
+    DEFAULT_TEMPERATURE_THRESHOLD,
+    DOMAIN,
+    ControlMode,
+)
 from .coordinator import HomeRulesConfigEntry, HomeRulesCoordinator
 
 AEC = AddEntitiesCallback
@@ -210,6 +224,108 @@ class HomeRulesEvaluateButton(HomeRulesEntity, ButtonEntity):
         await self.coordinator.async_run_evaluation("manual")
 
 
+@dataclass(frozen=True)
+class NumberDescription(NumberEntityDescription):
+    conf_key: str = ""
+    default: float = 0.0
+    object_id: str | None = None
+
+
+NUMBERS = (
+    NumberDescription(
+        key="temperature_threshold",
+        name="Temperature Threshold",
+        icon="mdi:thermometer-alert",
+        native_min_value=0,
+        native_max_value=40,
+        native_step=0.5,
+        native_unit_of_measurement="°C",
+        entity_category=EntityCategory.CONFIG,
+        conf_key=CONF_TEMPERATURE_THRESHOLD,
+        default=DEFAULT_TEMPERATURE_THRESHOLD,
+        object_id=f"{DOMAIN}_temperature_threshold",
+    ),
+    NumberDescription(
+        key="temperature_cool",
+        name="Cool Setpoint",
+        icon="mdi:thermometer-chevron-down",
+        native_min_value=0,
+        native_max_value=40,
+        native_step=0.5,
+        native_unit_of_measurement="°C",
+        entity_category=EntityCategory.CONFIG,
+        conf_key=CONF_TEMPERATURE_COOL,
+        default=DEFAULT_TEMPERATURE_COOL,
+        object_id=f"{DOMAIN}_cool_setpoint",
+    ),
+    NumberDescription(
+        key="generation_cool_threshold",
+        name="Cool Generation Threshold",
+        icon="mdi:solar-power",
+        native_min_value=0,
+        native_max_value=20000,
+        native_step=100,
+        native_unit_of_measurement="W",
+        entity_category=EntityCategory.CONFIG,
+        conf_key=CONF_GENERATION_COOL_THRESHOLD,
+        default=DEFAULT_GENERATION_COOL_THRESHOLD,
+        object_id=f"{DOMAIN}_cool_generation_threshold",
+    ),
+    NumberDescription(
+        key="generation_dry_threshold",
+        name="Dry Generation Threshold",
+        icon="mdi:solar-power-variant",
+        native_min_value=0,
+        native_max_value=20000,
+        native_step=100,
+        native_unit_of_measurement="W",
+        entity_category=EntityCategory.CONFIG,
+        conf_key=CONF_GENERATION_DRY_THRESHOLD,
+        default=DEFAULT_GENERATION_DRY_THRESHOLD,
+        object_id=f"{DOMAIN}_dry_generation_threshold",
+    ),
+    NumberDescription(
+        key="humidity_threshold",
+        name="Humidity Threshold",
+        icon="mdi:water-percent-alert",
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        native_unit_of_measurement="%",
+        entity_category=EntityCategory.CONFIG,
+        conf_key=CONF_HUMIDITY_THRESHOLD,
+        default=DEFAULT_HUMIDITY_THRESHOLD,
+        object_id=f"{DOMAIN}_humidity_threshold",
+    ),
+)
+
+
+class HomeRulesNumberEntity(HomeRulesEntity, NumberEntity):
+    entity_description: NumberDescription
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        entry: HomeRulesConfigEntry,
+        coordinator: HomeRulesCoordinator,
+        description: NumberDescription,
+    ) -> None:
+        super().__init__(
+            entry,
+            coordinator,
+            unique_id_suffix=description.key,
+            object_id=description.object_id or f"{DOMAIN}_{description.key}",
+        )
+        self.entity_description = description
+
+    @property
+    def native_value(self) -> float:
+        return self.coordinator.get_parameter(self.entity_description.conf_key, self.entity_description.default)
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.async_set_parameter(self.entity_description.conf_key, value)
+
+
 async def async_setup_sensor_entry(hass: HomeAssistant, entry: HCE, add_entities: AEC) -> None:
     add_entities(HomeRulesSensor(entry, entry.runtime_data, description) for description in SENSORS)
 
@@ -228,3 +344,7 @@ async def async_setup_switch_entry(hass: HomeAssistant, entry: HCE, add_entities
 
 async def async_setup_button_entry(hass: HomeAssistant, entry: HCE, add_entities: AEC) -> None:
     add_entities([HomeRulesEvaluateButton(entry, entry.runtime_data)])
+
+
+async def async_setup_number_entry(hass: HomeAssistant, entry: HCE, add_entities: AEC) -> None:
+    add_entities(HomeRulesNumberEntity(entry, entry.runtime_data, description) for description in NUMBERS)

--- a/custom_components/home_rules/icons.json
+++ b/custom_components/home_rules/icons.json
@@ -45,6 +45,23 @@
       "evaluate_now": {
         "default": "mdi:play-circle-outline"
       }
+    },
+    "number": {
+      "temperature_threshold": {
+        "default": "mdi:thermometer-alert"
+      },
+      "temperature_cool": {
+        "default": "mdi:thermometer-chevron-down"
+      },
+      "generation_cool_threshold": {
+        "default": "mdi:solar-power"
+      },
+      "generation_dry_threshold": {
+        "default": "mdi:solar-power-variant"
+      },
+      "humidity_threshold": {
+        "default": "mdi:water-percent-alert"
+      }
     }
   }
 }

--- a/custom_components/home_rules/number.py
+++ b/custom_components/home_rules/number.py
@@ -1,0 +1,6 @@
+from .entities import NUMBERS
+from .entities import async_setup_number_entry as async_setup_entry
+
+PARALLEL_UPDATES = 0
+
+__all__ = ["NUMBERS", "async_setup_entry"]

--- a/custom_components/home_rules/strings.json
+++ b/custom_components/home_rules/strings.json
@@ -102,6 +102,23 @@
       "evaluate_now": {
         "name": "Evaluate Now"
       }
+    },
+    "number": {
+      "temperature_threshold": {
+        "name": "Temperature Threshold"
+      },
+      "temperature_cool": {
+        "name": "Cool Setpoint"
+      },
+      "generation_cool_threshold": {
+        "name": "Cool Generation Threshold"
+      },
+      "generation_dry_threshold": {
+        "name": "Dry Generation Threshold"
+      },
+      "humidity_threshold": {
+        "name": "Humidity Threshold"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/home_rules/translations/en.json
+++ b/custom_components/home_rules/translations/en.json
@@ -102,6 +102,23 @@
       "evaluate_now": {
         "name": "Evaluate Now"
       }
+    },
+    "number": {
+      "temperature_threshold": {
+        "name": "Temperature Threshold"
+      },
+      "temperature_cool": {
+        "name": "Cool Setpoint"
+      },
+      "generation_cool_threshold": {
+        "name": "Cool Generation Threshold"
+      },
+      "generation_dry_threshold": {
+        "name": "Dry Generation Threshold"
+      },
+      "humidity_threshold": {
+        "name": "Humidity Threshold"
+      }
     }
   },
   "exceptions": {

--- a/tests/test_number_entities.py
+++ b/tests/test_number_entities.py
@@ -1,0 +1,78 @@
+"""Tests for number entity registration and coordinator parameter overrides."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+
+async def test_number_entities_register_on_setup(hass, loaded_entry) -> None:
+    for entity_id in (
+        "number.home_rules_temperature_threshold",
+        "number.home_rules_cool_setpoint",
+        "number.home_rules_cool_generation_threshold",
+        "number.home_rules_dry_generation_threshold",
+        "number.home_rules_humidity_threshold",
+    ):
+        assert hass.states.get(entity_id) is not None, f"{entity_id} not found"
+
+
+async def test_number_entities_show_default_values(hass, loaded_entry) -> None:
+    from custom_components.home_rules.const import (
+        DEFAULT_GENERATION_COOL_THRESHOLD,
+        DEFAULT_GENERATION_DRY_THRESHOLD,
+        DEFAULT_HUMIDITY_THRESHOLD,
+        DEFAULT_TEMPERATURE_COOL,
+        DEFAULT_TEMPERATURE_THRESHOLD,
+    )
+
+    assert float(hass.states.get("number.home_rules_temperature_threshold").state) == DEFAULT_TEMPERATURE_THRESHOLD
+    assert float(hass.states.get("number.home_rules_cool_setpoint").state) == DEFAULT_TEMPERATURE_COOL
+    cool_gen = hass.states.get("number.home_rules_cool_generation_threshold").state
+    assert float(cool_gen) == DEFAULT_GENERATION_COOL_THRESHOLD
+    dry_gen = hass.states.get("number.home_rules_dry_generation_threshold").state
+    assert float(dry_gen) == DEFAULT_GENERATION_DRY_THRESHOLD
+    assert float(hass.states.get("number.home_rules_humidity_threshold").state) == DEFAULT_HUMIDITY_THRESHOLD
+
+
+async def test_set_number_entity_updates_parameter(hass, loaded_entry) -> None:
+    from homeassistant.const import ATTR_ENTITY_ID
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {ATTR_ENTITY_ID: "number.home_rules_temperature_threshold", "value": 26.0},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert float(hass.states.get("number.home_rules_temperature_threshold").state) == 26.0
+
+
+async def test_get_parameter_falls_back_to_options(coord_factory) -> None:
+    from custom_components.home_rules.const import CONF_TEMPERATURE_THRESHOLD, DEFAULT_TEMPERATURE_THRESHOLD
+
+    coordinator = await coord_factory(options={CONF_TEMPERATURE_THRESHOLD: 27.0})
+    assert coordinator.get_parameter(CONF_TEMPERATURE_THRESHOLD, DEFAULT_TEMPERATURE_THRESHOLD) == 27.0
+
+
+async def test_get_parameter_override_takes_precedence(coord_factory) -> None:
+    from custom_components.home_rules.const import CONF_TEMPERATURE_THRESHOLD, DEFAULT_TEMPERATURE_THRESHOLD
+
+    coordinator = await coord_factory(options={CONF_TEMPERATURE_THRESHOLD: 27.0})
+    await coordinator.async_set_parameter(CONF_TEMPERATURE_THRESHOLD, 30.0)
+
+    assert coordinator.get_parameter(CONF_TEMPERATURE_THRESHOLD, DEFAULT_TEMPERATURE_THRESHOLD) == 30.0
+
+
+async def test_parameter_override_affects_evaluation(coord_factory) -> None:
+    from custom_components.home_rules.const import CONF_TEMPERATURE_THRESHOLD
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(temperature="25", generation="6000")
+    await coordinator.async_run_evaluation("test")
+    assert coordinator.data.adjustment is HomeOutput.COOL
+
+    await coordinator.async_set_parameter(CONF_TEMPERATURE_THRESHOLD, 30.0)
+    assert coordinator.data.reason == "Temperature below threshold"

--- a/uv.lock
+++ b/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.1.3"
+version = "1.1.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Adds five `number` entities so threshold parameters can be adjusted from the Home Assistant main page without entering settings:

| Entity | Default |
|---|---|
| Temperature Threshold | 24 °C |
| Cool Setpoint | 22 °C |
| Cool Generation Threshold | 5500 W |
| Dry Generation Threshold | 3500 W |
| Humidity Threshold | 65 % |

Values are a runtime override layer on top of config entry options — fast to change, no reload required, persisted across restarts.

**Key implementation detail:** `entity_description: NumberDescription` type narrowing in `HomeRulesNumberEntity` eliminates redundant instance variables seen in Copilot's attempt.

Closes #19
Supersedes #20