### PR TITLE
chore(deps): weekly lockfile update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.7.0"
+version = "1.7.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Downloading cpython-3.14.3-linux-x86_64-gnu (download) (34.4MiB)
 Downloaded cpython-3.14.3-linux-x86_64-gnu (download)
Using CPython 3.14.3
Resolved 166 packages in 290ms
Updated ha-home-rules v1.7.0 -> v1.7.1
