### PR TITLE
chore(deps): weekly lockfile update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.7.3"
+version = "1.7.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Downloading cpython-3.14.3-linux-x86_64-gnu (download) (34.4MiB)
 Downloaded cpython-3.14.3-linux-x86_64-gnu (download)
Using CPython 3.14.3
Resolved 166 packages in 408ms
Updated ha-home-rules v1.7.3 -> v1.7.4
