### PR TITLE
chore(deps): weekly lockfile update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.8.0"
+version = "1.8.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Downloading cpython-3.14.3-linux-x86_64-gnu (download) (34.4MiB)
 Downloaded cpython-3.14.3-linux-x86_64-gnu (download)
Using CPython 3.14.3
Resolved 159 packages in 420ms
Updated ha-home-rules v1.8.0 -> v1.8.1
