### PR TITLE
build: drop redundant pytest/pytest-asyncio/coverage pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,7 @@ requires-python = ">=3.14.2,<3.15"
 
 [dependency-groups]
 dev = [
-    "coverage>=7.10.6",
     "mypy>=1.15",
-    "pytest>=9.0.0",
-    "pytest-asyncio>=1.3.0",
     "pytest-homeassistant-custom-component>=0.13.316",
     "ruff>=0.9",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -854,15 +854,12 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.10.20"
+version = "1.10.21"
 source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "coverage" },
     { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
 ]
@@ -871,10 +868,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coverage", specifier = ">=7.10.6" },
     { name = "mypy", specifier = ">=1.15" },
-    { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.316" },
     { name = "ruff", specifier = ">=0.9" },
 ]


### PR DESCRIPTION
These three test dependencies are exact-pinned by `pytest-homeassistant-custom-component` (the HA test stack):

- `pytest==9.0.0`
- `pytest-asyncio==1.3.0`
- `coverage==7.10.6`

Declaring them as direct dev dependencies has no resolver effect (PHCC's exact pins win) but causes Renovate to create misleading update PRs that cannot actually advance the version (#79 is an example — claims to bump pytest to 9.0.3 but produces a no-op diff because PHCC's pin blocks it).

After this change, pytest stack updates flow only via PHCC bumps, which is the correct model for HA integration test suites.

Verified locally: `uv lock` produces only the expected structural changes — no actual package version regressions.