### PR TITLE
ci: stagger cron and pin floating action refs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "14 6 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "14 6 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b  # master pinned 2026-05-07
 
   hacs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: hacs/action@main
+      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485  # main pinned 2026-05-07
         with:
           category: integration
           comment: false

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "schedule": [
     "before 7am on Monday"
   ],
+  "pinDigests": true,
   "automerge": true,
   "platformAutomerge": true,
   "lockFileMaintenance": {


### PR DESCRIPTION
Staggers scheduled workflow minutes from :00 to :14 to reduce cron-herd pressure.

Pins the floating Hassfest and HACS action refs to immutable SHAs while preserving Renovate digest pinning.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>