### PR TITLE
build(deps): adopt shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,41 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Australia/Sydney",
-  "schedule": [
-    "before 7am on Monday"
-  ],
-  "pinDigests": true,
-  "automerge": true,
-  "platformAutomerge": true,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 7am on Monday"
-    ],
-    "commitMessageAction": "upgrade"
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "groupName": "all non-major"
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "all major"
-    }
-  ],
-  "commitMessagePrefix": "build(deps):"
+  "extends": ["github>teh-hippo/common-repo-configs//renovate/slots/tue-0700.json5"]
 }


### PR DESCRIPTION
Migrates to the shared preset at `teh-hippo/common-repo-configs` (slot `tue-0700`).