### PR TITLE
ci: adopt uv sync --locked pattern

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
+      - run: uv sync --locked
+      - run: uv run --no-sync ruff check .
+      - run: uv run --no-sync ruff format --check .
 
   mypy:
     name: Mypy
@@ -52,7 +53,8 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run mypy custom_components/home_rules tests
+      - run: uv sync --locked
+      - run: uv run --no-sync mypy custom_components/home_rules tests
 
   test:
     name: Test
@@ -62,5 +64,6 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run coverage run -m pytest tests/ -v --tb=short
-      - run: uv run coverage report --include="custom_components/home_rules/*" --fail-under=80
+      - run: uv sync --locked
+      - run: uv run --no-sync coverage run -m pytest tests/ -v --tb=short
+      - run: uv run --no-sync coverage report --include="custom_components/home_rules/*" --fail-under=80

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "=== Lint ==="
-uv run ruff check .
-uv run ruff format --check .
+uv sync --locked
+
+uv run --no-sync ruff check .
+uv run --no-sync ruff format --check .
 
 echo "=== Mypy ==="
-uv run mypy custom_components/home_rules tests
+uv run --no-sync mypy custom_components/home_rules tests
 
 echo "=== Test + Coverage ==="
-uv run coverage run -m pytest tests/ -v --tb=short
-uv run coverage report --include="custom_components/home_rules/*" --fail-under=80
+uv run --no-sync coverage run -m pytest tests/ -v --tb=short
+uv run --no-sync coverage report --include="custom_components/home_rules/*" --fail-under=80
 
 echo ""
 echo "✅ All checks passed — safe to push."

--- a/uv.lock
+++ b/uv.lock
@@ -860,7 +860,7 @@ wheels = [
 
 [[package]]
 name = "ha-home-rules"
-version = "1.10.26"
+version = "1.10.28"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Replace plain `uv run` invocations with one `uv sync --locked` per CI job followed by `uv run --no-sync` per command. Fleet rollout following pilot in [teh-hippo/ha-govee-led-ble#65](https://github.com/teh-hippo/ha-govee-led-ble/pull/65).

## Why

- **Deterministic** - the installed env matches the committed lockfile exactly.
- **Drift-safe** - `--locked` fails loudly if `pyproject.toml` and `uv.lock` disagree.

## What changed

- `.github/workflows/validate.yml` - each job that uses uv gains an `uv sync --locked` step; subsequent commands use `uv run --no-sync`.
- `scripts/check.sh` (where present) - same pattern.
- `uv.lock` - one-line refresh for project version drift. The release workflow had been bumping `pyproject.toml` without committing the resulting lock change.

## Validation

- `bash scripts/check.sh` (or equivalent) passes locally.
- Negative test on pilot confirmed: drift between `pyproject.toml` and `uv.lock` now fails `uv sync --locked` with exit 1.

## Known follow-up (not in this PR)

The release workflow runs `uv lock` via `build_command` but python-semantic-release does not commit `uv.lock` (only `pyproject.toml` + `manifest.json`). Each release will reintroduce drift until that is fixed. Tracked separately.