### PR TITLE
ci(release): commit uv.lock from build_command via assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ version_variables = [
 build_command = "pip install uv && uv lock"
 commit_message = "chore(release): {version}"
 tag_format = "v{version}"
+assets = ["uv.lock"]
 
 [tool.semantic_release.commit_parser_options]
 patch_tags = ["fix", "perf", "build"]


### PR DESCRIPTION
## Problem

After adopting `uv sync --locked` in Validate, every release leaves master with `pyproject.toml` and `manifest.json` bumped to vX.Y.Z but `uv.lock` still at vX.Y.(Z-1). The next PR onto master then red-fails CI on `uv sync --locked` with a project-version drift error.

Root cause: `python-semantic-release` v10 only commits files declared in `version_toml`, `version_variables`, the changelog, and `assets`. Our `build_command` already runs `uv lock`, but because `uv.lock` is not in `assets`, the refreshed file is discarded after the build step.

## Fix

Add `assets = ["uv.lock"]` to `[tool.semantic_release]`. PSR's documented version flow runs `build_command` after the version files are written and before the commit, so `uv lock` produces a lockfile matching the bumped version and PSR includes it in the `chore(release):` commit via `assets`.

## Validation

Fix was proven end-to-end on the pilot repo (teh-hippo/ha-govee-led-ble#66) via a real local PSR dry-run (`semantic-release version --patch --no-push --no-vcs-release --no-tag`). The resulting `chore(release):` commit contained `uv.lock` alongside the version files, and `uv sync --locked` passed against the simulated release commit.

This repo's `[tool.semantic_release]` block is structurally identical to the pilot's; preflight confirmed `uv.lock` at repo root and `branches.master.match = "master"`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>