### PR TITLE
fix: overnight auto-off requires live solar telemetry, not just an online inverter status

### DIFF
--- a/custom_components/home_rules/const.py
+++ b/custom_components/home_rules/const.py
@@ -45,6 +45,14 @@ def normalize_power_unit(unit: str) -> str:
     return _POWER_UNITS.get(cleaned.lower(), cleaned)
 
 
+INVERTER_ONLINE_STATES = frozenset({"on", "true", "1", "online"})
+
+
+def is_inverter_online(state: str) -> bool:
+    """True when an inverter status string denotes an online, producing inverter."""
+    return state.lower().strip().replace("-", "").replace("_", "").replace(" ", "") in INVERTER_ONLINE_STATES
+
+
 DEFAULT_OPTIONS: dict[str, int | float] = {
     CONF_AIRCON_TIMER_DURATION: DEFAULT_AIRCON_TIMER_DURATION,
     CONF_EVAL_INTERVAL: DEFAULT_EVAL_INTERVAL,

--- a/custom_components/home_rules/coordinator.py
+++ b/custom_components/home_rules/coordinator.py
@@ -9,7 +9,13 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfPower,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
@@ -164,7 +170,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
         timer = self._active_aircon_timer(); climate = self._state(c.CONF_CLIMATE_ENTITY_ID, "climate")
         inv_id = self._entity_id(c.CONF_INVERTER_ENTITY_ID, optional=True); inv = self._get_state(inv_id, "inverter", allow_unavailable=True) if inv_id else None
         gen = self._state(c.CONF_GENERATION_ENTITY_ID, "generation", allow_unavailable=True); grid = self._state(c.CONF_GRID_ENTITY_ID, "grid", allow_unavailable=True); temp = self._state(c.CONF_TEMPERATURE_ENTITY_ID, "temperature", allow_unavailable=True); hum = self._state(c.CONF_HUMIDITY_ENTITY_ID, "humidity", allow_unavailable=True)
-        have_solar = str(inv.state).lower().strip().replace("-", "").replace("_", "").replace(" ", "") in {"on", "true", "1", "online"} if inv else not inv_id
+        have_solar = (c.is_inverter_online(str(inv.state)) if inv else True) and "generation" not in self._fallback_inputs  # a stuck/stale online status with no live generation telemetry (asleep inverter) is not solar
         mode = AirconMode.UNKNOWN
         with suppress(ValueError): mode = AirconMode(str(climate.state).lower().strip())
         aggressive = self.control_mode is c.ControlMode.BOOST_COOLING; enabled = self.control_mode is not c.ControlMode.DISABLED
@@ -201,7 +207,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
             if not allow_unavailable and not self._first_refresh_done: raise ConfigEntryNotReady(f"Required entity not yet available: {entity_id}")
             self._create_issue(c.ISSUE_ENTITY_MISSING, {"entity_id": entity_id, "label": label}); raise ValueError(f"missing entity: {entity_id}")
         raw = str(state.state).lower()
-        if raw not in {"unknown", "unavailable"}: return state
+        if raw not in {STATE_UNKNOWN, STATE_UNAVAILABLE}: return state
         if not allow_unavailable:
             if not self._first_refresh_done: raise ConfigEntryNotReady(f"Required entity not yet available: {entity_id}")
             self._create_issue(c.ISSUE_ENTITY_UNAVAILABLE, {"entity_id": entity_id, "label": label}); raise ValueError(f"entity unavailable: {entity_id}")

--- a/tests/test_coordinator_scenarios.py
+++ b/tests/test_coordinator_scenarios.py
@@ -181,3 +181,30 @@ async def test_restart_first_eval_uses_live_state_when_no_stored_session(coord_f
 
     # Session must be initialised from live state, not left as None.
     assert coordinator._session.last is not None
+
+
+async def test_online_inverter_without_generation_telemetry_is_not_solar(coord_factory) -> None:
+    """An inverter stuck 'on-line' with no generation telemetry (asleep at night) is not solar.
+
+    Regression: a stale online status previously masked the sleeping inverter, so a manually
+    run aircon was treated as running on free solar and never capped by the overnight timer.
+    """
+    coordinator = await coord_factory(inverter="on-line", generation="unknown", grid="unknown", climate="heat")
+    await coordinator.async_run_evaluation("poll")
+
+    assert coordinator._last_record["have_solar"] is False
+    assert coordinator.data.solar_available is False
+
+
+async def test_online_inverter_without_telemetry_arms_overnight_timer(coord_factory) -> None:
+    """With no live solar telemetry, a manually run aircon is capped by the overnight timer."""
+    from custom_components.home_rules.const import ControlMode
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="on-line", generation="unknown", grid="unknown", climate="heat")
+    await coordinator.async_set_mode(ControlMode.SOLAR_COOLING)
+
+    assert coordinator._last_record["have_solar"] is False
+    assert coordinator.data.adjustment is HomeOutput.TIMER
+    assert coordinator._aircon_timer_finishes_at is not None
+    await coordinator.async_shutdown()


### PR DESCRIPTION
## What was happening

Overnight, the aircon was left heating for ~5.5 hours instead of being turned off after an hour. Investigation on the live instance showed the decision engine returned `No Change` on every evaluation because `have_solar` was `true` all night.

Root cause: `have_solar` was derived solely from the inverter status entity (`sensor.foxess_inverter`). At dusk the inverter goes to sleep, its generation/grid telemetry becomes `unknown`, and the status normally flips to `off-line`. On the night in question the status sensor got stuck at `on-line` (first desync in 10 days) while generation telemetry was `unknown` as usual. With `have_solar` stuck `true` and grid usage falling back to `0`, a manually run aircon was classified as running on free solar, so the overnight timer never armed. During the day the timer still worked because real grid draw armed it, which is why the fault only showed overnight.

## The fix

Treat solar as available only when the inverter reports online **and** the generation sensor is reporting live data. Unavailable or unknown generation now counts as no solar, so a stale or stuck online status can no longer mask a sleeping inverter. This keeps the intended daytime behaviour (a manually run aircon is left alone while there is genuine free solar) while restoring the overnight cap.

I fixed the input (`have_solar`) rather than decoupling the timer from the solar branch, because the branch's intent is correct: the cap should apply when there is no free solar, and the bug was a lying input, not a wrong rule.

Also lifts the inverter online-state set into `const.is_inverter_online` and uses `STATE_UNAVAILABLE`/`STATE_UNKNOWN` instead of string literals.

## Tests

- `test_online_inverter_without_generation_telemetry_is_not_solar` — stuck `on-line` with no telemetry is not solar.
- `test_online_inverter_without_telemetry_arms_overnight_timer` — a manual run then arms the overnight timer.
- Existing `test_inverter_on_line_treated_as_online` still passes (online with live generation is solar).

`bash scripts/check.sh` passes: 186 tests, 92% coverage, lint and mypy clean.
