### PR TITLE
fix: harden overnight cap against missing solar telemetry and restarts

### DIFF
--- a/custom_components/home_rules/coordinator.py
+++ b/custom_components/home_rules/coordinator.py
@@ -37,7 +37,7 @@ from .rules import (
     current_state,
 )
 
-_HOME_RECORD_FIELDS = ("generation", "grid_usage", "temperature", "humidity", "have_solar", "auto")
+_HOME_RECORD_FIELDS = ("generation", "grid_usage", "temperature", "humidity", "have_solar", "solar_unknown", "auto", "aircon_mode")
 _SESSION_RECORD_FIELDS = ("tolerated", "reactivate_delay")
 _CLEAR_ISSUES = (c.ISSUE_RUNTIME, c.ISSUE_ENTITY_MISSING, c.ISSUE_INVALID_UNIT, c.ISSUE_ENTITY_UNAVAILABLE)
 
@@ -117,7 +117,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
             previous = self._session.last; applied = apply_adjustment(self._session, current, adjustment); is_monitor = self.control_mode is c.ControlMode.MONITOR
             if is_monitor: self._session.failed_to_change, applied = 0, True
             if not applied: raise HomeAssistantError("failed to apply adjustment")
-            if previous is not None and previous != self._session.last: self._last_changed = now; await self._maybe_notify(previous, current, adjustment)
+            if previous is not None and previous != self._session.last and adjustment is not HomeOutput.RESET: self._last_changed = now; await self._maybe_notify(previous, current, adjustment)
             mode = self._session.last or current
             record = {"time": now, "trigger": trigger, "current": current.value, "adjustment": adjustment.value, "mode": mode.value, "reason": reason, "dry_run": is_monitor, "control_mode": self.control_mode.value, "target_adjustment": target.output.value if target.output is not None else None, "target_reason": target.reason, "target_actionable": target.is_actionable, "blocked_reasons": [target.reason] if target.output is None and target.is_actionable else [], "fallback_inputs": dict(self._fallback_inputs), "controls_snapshot": {"control_mode": self.control_mode.value, "cooling_enabled": self.cooling_enabled, "dry_mode_enabled": self.dry_mode_enabled}, "policy_snapshot": {"dry_mode_humidity_cutoff": params.dry_mode_humidity_cutoff}} | {k: getattr(home, k) for k in _HOME_RECORD_FIELDS} | {k: getattr(self._session, k) for k in _SESSION_RECORD_FIELDS}
             smoothed = self._run_shadow_smoothed(home, record)
@@ -126,7 +126,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
             for issue in _CLEAR_ISSUES: self._clear_issue(issue)
             self._first_refresh_done = True
             disagree_count = sum(1 for r in list(self._recent)[:10] if r.get("decision_differs", False))
-            return CoordinatorData(mode=mode, current=current, adjustment=adjustment, decision=f"{mode.value} - {reason}", reason=reason, solar_available=home.have_solar and home.generation > 0.0, auto_mode=self._auto_mode, dry_run=is_monitor, timer_finishes_at=timer, last_evaluated=now, last_changed=self._last_changed, smoothing_disagrees=disagree_count)
+            return CoordinatorData(mode=mode, current=current, adjustment=adjustment, decision=f"{mode.value} - {reason}", reason=reason, solar_available=home.have_solar, auto_mode=self._auto_mode, dry_run=is_monitor, timer_finishes_at=timer, last_evaluated=now, last_changed=self._last_changed, smoothing_disagrees=disagree_count)
 
     async def _maybe_notify(self, previous: HomeOutput, current: HomeOutput, adjustment: HomeOutput) -> None:
         service = str(self.config_entry.options.get(c.CONF_NOTIFICATION_SERVICE, "")).strip()
@@ -170,16 +170,20 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
         timer = self._active_aircon_timer(); climate = self._state(c.CONF_CLIMATE_ENTITY_ID, "climate")
         inv_id = self._entity_id(c.CONF_INVERTER_ENTITY_ID, optional=True); inv = self._get_state(inv_id, "inverter", allow_unavailable=True) if inv_id else None
         gen = self._state(c.CONF_GENERATION_ENTITY_ID, "generation", allow_unavailable=True); grid = self._state(c.CONF_GRID_ENTITY_ID, "grid", allow_unavailable=True); temp = self._state(c.CONF_TEMPERATURE_ENTITY_ID, "temperature", allow_unavailable=True); hum = self._state(c.CONF_HUMIDITY_ENTITY_ID, "humidity", allow_unavailable=True)
-        have_solar = (c.is_inverter_online(str(inv.state)) if inv else True) and "generation" not in self._fallback_inputs  # a stuck/stale online status with no live generation telemetry (asleep inverter) is not solar
+        gen_live = "generation" not in self._fallback_inputs; grid_live = "grid" not in self._fallback_inputs  # a fallback means the sensor is unknown/unavailable (e.g. inverter asleep)
+        generation = self._normalized_power(gen, "generation") if gen_live else 0.0; grid_usage = self._normalized_power(grid, "grid") if grid_live else 0.0  # normalise only live readings; a stale fallback stays 0
+        inverter_online = c.is_inverter_online(str(inv.state)) if inv else True
+        have_solar = inverter_online and gen_live and generation > 0.0  # solar present: inverter up AND live, positive generation
+        solar_unknown = inverter_online and not gen_live  # inverter claims online but no telemetry, so solar cannot be confirmed (vs offline = confirmed no solar)
         mode = AirconMode.UNKNOWN
         with suppress(ValueError): mode = AirconMode(str(climate.state).lower().strip())
         aggressive = self.control_mode is c.ControlMode.BOOST_COOLING; enabled = self.control_mode is not c.ControlMode.DISABLED
-        generation = self._normalized_power(gen, "generation") if have_solar else 0.0; grid_usage = self._normalized_power(grid, "grid") if have_solar else 0.0
-        return HomeInput(mode, have_solar, generation, grid_usage, timer is not None, self._normalized_temperature(temp), self._state_to_float(hum, "humidity"), self._auto_mode, aggressive, enabled, self.cooling_enabled), timer
+        return HomeInput(mode, have_solar, generation, grid_usage, timer is not None, self._normalized_temperature(temp), self._state_to_float(hum, "humidity"), self._auto_mode, aggressive, enabled, self.cooling_enabled, solar_unknown), timer
 
     def _sync_on_startup(self, current: HomeOutput, home: HomeInput) -> None:
         if self._session.last is None: self._session.last = current
         elif home.timer and self._session.last is HomeOutput.TIMER: return
+        elif self._session.last is HomeOutput.TIMER and home.aircon_mode is not AirconMode.OFF: return  # cap elapsed while down but aircon still on: keep TIMER so adjust() issues OFF, don't re-arm
         elif self._session.last != current: c.LOGGER.info("Startup sync: restoring from %s to live state %s", self._session.last.value, current.value); self._session.last = current
 
     async def _call_service(self, domain: str, service: str, data: dict[str, Any]) -> None:
@@ -234,7 +238,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self._cancel_timer_expiry()
         if self._aircon_timer_finishes_at is None: return
         delay = (self._aircon_timer_finishes_at - dt_util.utcnow()).total_seconds()
-        if delay <= 0: self.hass.loop.call_soon(self._async_handle_timer_expiry); return
+        if delay <= 0: return  # already elapsed (e.g. a cap loaded on restart): the imminent evaluation clears it and issues OFF, avoiding a second racing eval that could re-arm
         self._timer_expiry_handle = self.hass.loop.call_later(delay, self._async_handle_timer_expiry)
 
     def _async_handle_timer_expiry(self) -> None:

--- a/custom_components/home_rules/rules.py
+++ b/custom_components/home_rules/rules.py
@@ -17,6 +17,8 @@ from enum import StrEnum
 from typing import NamedTuple
 
 ALLOWED_FAILURES = 3
+# Evaluations to keep an auto run alive while solar telemetry is missing before failing safe to OFF.
+UNKNOWN_HOLD_LIMIT = 6
 
 # Reason constants — every decision path has a named reason.
 R_NO_SOLAR = "No solar available"
@@ -42,6 +44,7 @@ R_NO_CHANGE = "No change"
 R_COOLING_DISABLED = "Cooling disabled"
 R_BELOW_COOL_SETPOINT = "Temperature below cool setpoint"
 R_BELOW_THRESHOLD = "Temperature below threshold"
+R_SOLAR_UNKNOWN = "Solar telemetry unavailable"
 
 
 class AirconMode(StrEnum):
@@ -81,6 +84,7 @@ class HomeInput:
     aggressive_cooling: bool
     enabled: bool
     cooling_enabled: bool
+    solar_unknown: bool = False
 
 
 @dataclass
@@ -232,6 +236,15 @@ def adjust(config: RuleParameters, home: HomeInput, state: CachedState) -> Adjus
             if h.aggressive_cooling and h.have_solar and h.generation >= config.generation_boost_threshold:
                 state.tolerated = 0
                 return AdjustResult(HomeOutput.NO_CHANGE, R_BOOST_GRID_TOLERATED)
+            # Telemetry gap: no live solar data and no measured grid draw, so hold rather than shut
+            # off active cooling on missing data. Bounded so a sustained outage still fails safe to OFF.
+            if h.solar_unknown and h.grid_usage <= 0:
+                state.tolerated += 1
+                if state.tolerated < UNKNOWN_HOLD_LIMIT:
+                    return AdjustResult(HomeOutput.NO_CHANGE, R_SOLAR_UNKNOWN)
+                state.tolerated = 0
+                state.reactivate_delay = config.reactivate_delay
+                return AdjustResult(HomeOutput.OFF, R_GRID_TOO_HIGH)
             # Solar: tolerate briefly, then shut off.
             state.tolerated += 1
             if state.tolerated < config.grid_usage_delay:
@@ -252,6 +265,9 @@ def adjust(config: RuleParameters, home: HomeInput, state: CachedState) -> Adjus
             return AdjustResult(target.output, target.reason)
         return AdjustResult(HomeOutput.NO_CHANGE, activation or R_NO_CHANGE)
 
+    # Manual run confirmed on genuine free solar: clear a now-stale expired cap.
+    if state.last is HomeOutput.TIMER and not h.timer:
+        return AdjustResult(HomeOutput.RESET, R_TIMER_EXPIRED)
     return AdjustResult(HomeOutput.NO_CHANGE, R_NO_CHANGE)
 
 

--- a/tests/test_coordinator_scenarios.py
+++ b/tests/test_coordinator_scenarios.py
@@ -208,3 +208,123 @@ async def test_online_inverter_without_telemetry_arms_overnight_timer(coord_fact
     assert coordinator.data.adjustment is HomeOutput.TIMER
     assert coordinator._aircon_timer_finishes_at is not None
     await coordinator.async_shutdown()
+
+
+async def test_live_zero_generation_with_stuck_online_inverter_caps_manual_run(coord_factory) -> None:
+    """H2: a live 0 W reading (not 'unknown') with a stuck-online inverter is confirmed no-solar.
+
+    have_solar must be False (requires generation > 0) and solar_unknown False, so a manual run
+    enters the timer branch and is capped, so the original overnight bug cannot recur via a real 0.
+    """
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="on-line", generation="0", grid="0", climate="heat")
+    await coordinator.async_run_evaluation("poll")
+
+    assert coordinator._last_record["have_solar"] is False
+    assert coordinator._last_record["solar_unknown"] is False
+    assert coordinator.data.adjustment is HomeOutput.TIMER
+
+
+async def test_auto_cooling_holds_on_unknown_generation(coord_factory) -> None:
+    """H1: an active auto-cooling run holds (does not shut off) when solar telemetry is missing."""
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="on-line", generation="unknown", grid="unknown", climate="cool")
+    coordinator._auto_mode = True
+    coordinator._session.last = HomeOutput.COOL
+    coordinator._initialized = True  # skip startup sync so the simulated auto run persists
+
+    await coordinator.async_run_evaluation("poll")
+
+    assert coordinator._last_record["solar_unknown"] is True
+    assert coordinator.data.adjustment is HomeOutput.NO_CHANGE
+    assert coordinator.data.reason == "Solar telemetry unavailable"
+
+
+async def test_auto_cooling_shuts_off_on_measured_grid_despite_unknown_solar(coord_factory) -> None:
+    """H1 boundary: a real measured grid import still shuts an auto run off (not held)."""
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="on-line", generation="unknown", grid="200", climate="cool")
+    coordinator._auto_mode = True
+    coordinator._session.last = HomeOutput.COOL
+    coordinator._initialized = True
+
+    await coordinator.async_run_evaluation("poll")  # tolerated=1
+    await coordinator.async_run_evaluation("poll")  # tolerated=grid_usage_delay -> OFF
+
+    assert coordinator.data.adjustment is HomeOutput.OFF
+    assert coordinator.data.reason == "Grid usage too high"
+
+
+async def test_restart_with_expired_timer_and_aircon_on_turns_off(coord_factory) -> None:
+    """M1: HA down when the cap elapsed, aircon still heating -> restart issues OFF, not a re-arm."""
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(climate="heat", generation="unknown", grid="unknown")
+    coordinator._session.last = HomeOutput.TIMER
+    coordinator._aircon_timer_finishes_at = None  # elapsed while HA was down
+    coordinator._initialized = False  # startup sync runs
+
+    await coordinator.async_run_evaluation("restart")
+
+    assert coordinator.data.adjustment is HomeOutput.OFF  # cap issues OFF instead of re-arming a fresh timer
+    assert coordinator.data.reason == "Timer expired"
+
+
+async def test_offline_inverter_is_confirmed_no_solar_not_unknown(coord_factory) -> None:
+    """An offline inverter is confirmed no-solar (not 'unknown'): an auto run shuts off, is not held."""
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="off-line", generation="unknown", grid="unknown", climate="cool")
+    coordinator._auto_mode = True
+    coordinator._session.last = HomeOutput.COOL
+    coordinator._initialized = True
+
+    await coordinator.async_run_evaluation("poll")  # tolerated=1
+    assert coordinator._last_record["solar_unknown"] is False
+    assert coordinator.data.reason == "Grid usage tolerated"
+
+    await coordinator.async_run_evaluation("poll")  # tolerated=grid_usage_delay -> OFF
+    assert coordinator.data.adjustment is HomeOutput.OFF
+
+
+async def test_free_solar_reset_of_stale_timer_does_not_notify(coord_factory) -> None:
+    """Clearing a stale expired cap under genuine free solar is internal: no notify, no last_changed bump."""
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(inverter="on-line", generation="6000", grid="0", climate="cool")
+    coordinator._session.last = HomeOutput.TIMER
+    coordinator._aircon_timer_finishes_at = None  # cap elapsed
+    coordinator._initialized = True
+    coordinator._last_changed = "sentinel"
+
+    await coordinator.async_run_evaluation("poll")
+
+    assert coordinator.data.adjustment is HomeOutput.RESET
+    assert coordinator._session.last is HomeOutput.COOL  # stale TIMER cleared to live state
+    assert coordinator._last_changed == "sentinel"  # RESET is internal, so no spurious mode-change notification
+
+
+async def test_restart_with_stored_elapsed_timer_issues_off_without_rescheduling(coord_factory) -> None:
+    """M1/hardening: a cap that elapsed while HA was down issues OFF via the first eval and does not
+    schedule a second, racing expiry callback that could re-arm."""
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.home_rules.rules import HomeOutput
+
+    coordinator = await coord_factory(climate="heat", generation="unknown", grid="unknown")
+    coordinator._session.last = HomeOutput.TIMER
+    coordinator._aircon_timer_finishes_at = dt_util.utcnow() - timedelta(minutes=5)  # elapsed while HA was down
+    coordinator._schedule_timer_expiry()  # as async_initialize would on restart
+
+    assert coordinator._timer_expiry_handle is None  # an already-elapsed cap must not schedule a racing callback
+
+    coordinator._initialized = False  # startup sync runs on the first evaluation
+    await coordinator.async_run_evaluation("restart")
+
+    assert coordinator.data.adjustment is HomeOutput.OFF
+    assert coordinator._aircon_timer_finishes_at is None

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -29,8 +29,10 @@ from custom_components.home_rules.rules import (
     R_REACTIVATE_WAIT,
     R_SOLAR_COOL,
     R_SOLAR_DRY,
+    R_SOLAR_UNKNOWN,
     R_TIMER_EXPIRED,
     R_UNKNOWN_MODE,
+    UNKNOWN_HOLD_LIMIT,
     AdjustResult,
     AirconMode,
     CachedState,
@@ -1422,3 +1424,92 @@ class TestReasonConstants:
             CachedState(),
         )
         assert r.reason == R_BELOW_THRESHOLD
+
+
+class TestAdjustSolarUnknown:
+    """Auto runs with missing solar telemetry hold (bounded), never shut off on missing data."""
+
+    def _unknown_auto(self, grid_usage: float = 0.0, **overrides):
+        return home(
+            aircon_mode=AirconMode.COOL,
+            have_solar=False,
+            solar_unknown=True,
+            grid_usage=grid_usage,
+            auto=True,
+            **overrides,
+        )
+
+    def test_holds_when_unknown_and_no_measured_grid(self):
+        r = adjust(TEST_PARAMS, self._unknown_auto(), CachedState(last=OUT.COOL))
+        assert r == AdjustResult(OUT.NO_CHANGE, R_SOLAR_UNKNOWN)
+
+    def test_bounded_hold_then_fails_safe_off(self):
+        state = CachedState(last=OUT.COOL)
+        h = self._unknown_auto()
+        for _ in range(UNKNOWN_HOLD_LIMIT - 1):
+            assert adjust(TEST_PARAMS, h, state) == AdjustResult(OUT.NO_CHANGE, R_SOLAR_UNKNOWN)
+        assert adjust(TEST_PARAMS, h, state) == AdjustResult(OUT.OFF, R_GRID_TOO_HIGH)
+
+    def test_measured_grid_still_shuts_off_despite_unknown(self):
+        state = CachedState(last=OUT.COOL)
+        h = self._unknown_auto(grid_usage=100.0)
+        assert adjust(TEST_PARAMS, h, state).reason == R_GRID_TOLERATED
+        assert adjust(TEST_PARAMS, h, state) == AdjustResult(OUT.OFF, R_GRID_TOO_HIGH)
+
+    def test_prior_unknown_holds_shorten_later_measured_grid_tolerance(self):
+        """Shared tolerated counter: unknown holds carry over so a later measured grid trips OFF
+        sooner, bounded and in the safe (shut-off) direction."""
+        state = CachedState(last=OUT.COOL)
+        assert adjust(TEST_PARAMS, self._unknown_auto(), state).reason == R_SOLAR_UNKNOWN  # tolerated=1
+        assert adjust(TEST_PARAMS, self._unknown_auto(), state).reason == R_SOLAR_UNKNOWN  # tolerated=2
+        # A real measured import now trips OFF immediately (tolerated already >= grid_usage_delay).
+        r = adjust(TEST_PARAMS, self._unknown_auto(grid_usage=100.0), state)
+        assert r == AdjustResult(OUT.OFF, R_GRID_TOO_HIGH)
+
+
+class TestAdjustManualFreeSolar:
+    """A manual run genuinely on free solar is left uncapped; a stale expired cap is cleared."""
+
+    def test_free_solar_manual_stays_uncapped(self):
+        r = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.COOL, have_solar=True, generation=6000, auto=False),
+            CachedState(last=OUT.COOL),
+        )
+        assert r == AdjustResult(OUT.NO_CHANGE, R_NO_CHANGE)
+
+    def test_free_solar_manual_resets_stale_expired_timer(self):
+        r = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.COOL, have_solar=True, generation=6000, auto=False),
+            CachedState(last=OUT.TIMER),
+        )
+        assert r == AdjustResult(OUT.RESET, R_TIMER_EXPIRED)
+
+
+class TestManualOvernightCapLifecycle:
+    """End-to-end pure-engine arm -> hold -> expire -> OFF for a manual no-solar run."""
+
+    def test_arm_hold_expire_off(self):
+        state = CachedState(last=OUT.OFF)
+        armed = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.HEAT, have_solar=False, grid_usage=0.0, timer=False, auto=False),
+            state,
+        )
+        assert armed == AdjustResult(OUT.TIMER, R_MANUAL)
+        assert apply_adjustment(state, OUT.COOL, OUT.TIMER) is True  # session.last -> TIMER
+
+        holding = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.HEAT, have_solar=False, grid_usage=0.0, timer=True, auto=False),
+            state,
+        )
+        assert holding == AdjustResult(OUT.NO_CHANGE, R_NO_CHANGE)
+
+        expired = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.HEAT, have_solar=False, grid_usage=0.0, timer=False, auto=False),
+            state,
+        )
+        assert expired == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)


### PR DESCRIPTION
## Context

Follow-up to #110 (v1.10.29). A multi-expert review of that fix surfaced one regression it introduced, one latent path back to the original overnight bug, a pre-existing restart edge, and some nits. This PR resolves them at the root.

## Changes

**Solar tri-state (coordinator).** `have_solar` now means "solar present": inverter online AND live, positive generation. A new `solar_unknown` marks an online inverter reporting no telemetry, distinct from a confirmed no-solar state (offline inverter, or a live `0 W`). Generation and grid are normalised only when live, so a stale fallback never masks or corrupts a real reading.

**H1 (regression fix).** An active auto-cooling run no longer shuts off on a brief telemetry gap. When solar is `unknown` and there is no measured grid draw, the run is held rather than shut down; the hold is bounded (`UNKNOWN_HOLD_LIMIT`) so a sustained outage still fails safe to OFF. A real measured grid import still shuts off as before.

**H2 (latent overnight bug).** Because `have_solar` now requires generation `> 0`, a live `0 W` reading with a stuck-online inverter is treated as confirmed no-solar, so a manual run is still capped by the overnight timer. The original bug cannot recur through a real zero.

**M1 (restart).** If Home Assistant is down when the cap elapses and the aircon is still on, startup now preserves the `TIMER` state so the run is turned off, instead of re-arming a fresh cap. An already-elapsed cap loaded on restart no longer schedules a second, racing evaluation.

**Nits.** Clearing a stale cap on genuine free solar no longer emits a spurious mode-change notification. Diagnostics now record `solar_unknown` and the true aircon mode.

## Decision recorded

Free solar is not gated on grid being live. With `have_solar` requiring generation `> 0`, entering the free-solar branch means real generation is present, and this FoxESS drops generation and grid together (so grid-unknown-while-generating is covered by `solar_unknown`). Gating on grid would trade a rare, bounded, cost-only masking for a worse false shut-off on a grid-only sensor blip. Tracked as future hardening for hardware where grid can drop independently.

## Tests

Added end-to-end and unit coverage: manual arm/hold/expire/OFF, bounded unknown-hold then fail-safe OFF, measured grid overriding the hold, offline inverter as confirmed no-solar (auto shuts off, not held), live-0 caps a manual run, restart with an elapsed stored cap issues OFF without rescheduling, and the free-solar RESET does not notify.

`bash scripts/check.sh` passes: 200 tests, 92% coverage, rules.py 100%, ruff and mypy clean.

Reviewed by Claude Opus 4.8 and GPT-5.5 (signed off, no blockers).
