### PR TITLE
fix(tests): cancel lingering aircon timer on coordinator fixture teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ else:
         """Enable custom component loading in HA tests."""
 
     @pytest.fixture
-    def coord_factory(hass):
+    async def coord_factory(hass):
         """Factory fixture: creates an initialized HomeRulesCoordinator with configurable HA states.
 
         Usage::
@@ -28,6 +28,9 @@ else:
             async def test_something(coord_factory) -> None:
                 coordinator = await coord_factory()           # default high-solar scenario
                 coordinator = await coord_factory(generation="0")  # no solar
+
+        Coordinators are shut down on teardown so scheduled timers do not linger
+        past the test, mirroring config-entry unload.
         """
         from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -41,6 +44,8 @@ else:
             DOMAIN,
         )
         from custom_components.home_rules.coordinator import HomeRulesCoordinator
+
+        created: list[HomeRulesCoordinator] = []
 
         async def _make(
             *,
@@ -74,9 +79,13 @@ else:
             entry.add_to_hass(hass)
             coordinator = HomeRulesCoordinator(hass, entry)
             await coordinator.async_initialize()
+            created.append(coordinator)
             return coordinator
 
-        return _make
+        yield _make
+
+        for coordinator in created:
+            await coordinator.async_shutdown()
 
     @pytest.fixture
     def mock_entry(hass):


### PR DESCRIPTION
## Problem

The Renovate lock-file-maintenance PR (#96) has a red `Test` check, blocking the weekly relock that would clear this repo's open Dependabot alerts. `master` is green because it still pins the older test toolchain.

Under the relocked dependencies (`pytest-homeassistant-custom-component` 0.13.325 -> 0.13.345, `homeassistant` 2026.4.4 -> 2026.7.1), the plugin is stricter about lingering asyncio timers and fails at teardown:

```
Failed: Lingering timer after test <TimerHandle ... HomeRulesCoordinator._async_handle_timer_expiry() created at coordinator.py:242>
ERROR at teardown of test_timer_countdown_uses_internal_timer_duration
```

## Root cause

`coord_factory` created `HomeRulesCoordinator` instances but never tore them down. When a test triggers a `TIMER` adjustment the coordinator schedules a real timer via `hass.loop.call_later(...)`. In production that handle is cancelled on config-entry unload (`async_unload_entry` -> `async_shutdown` -> `_cancel_timer_expiry`), but the fixture bypassed that lifecycle, so the timer lingered into teardown.

## Fix

Make `coord_factory` an async fixture that calls `async_shutdown()` on every coordinator it creates, mirroring config-entry unload. This is a lifecycle fix at the harness boundary rather than a per-test band-aid, so it covers every timer-scheduling test.

## Verification

Reproduced the failure with #96's relocked `uv.lock`, then confirmed green with the fix:

- Full suite under relocked deps: `200 passed`
- Full suite under `master` deps: `200 passed`
- Coverage 92% (gate 80), ruff, ruff-format and mypy all clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>