### PR TITLE
build(deps): pin hub reusable workflows to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    uses: teh-hippo/common-repo-configs/.github/workflows/codeql.yml@b3d0a782aa320db32e090a312e42e8da717e29b5  # main
+    uses: teh-hippo/common-repo-configs/.github/workflows/codeql.yml@5ee35e8b64328a970f0a85b963147b2b7e351886  # v2
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Standardise the pin for `teh-hippo/common-repo-configs` reusable workflow references onto the hub's `v2` tag, pinned by SHA `5ee35e8b64328a970f0a85b963147b2b7e351886`.

The referenced reusables are byte-identical between the previously pinned commit and `v2`, so this is a functional no-op that CI confirms.
