### PR TITLE
fix: cap and turn off manual heat runs regardless of solar

### DIFF
--- a/custom_components/home_rules/coordinator.py
+++ b/custom_components/home_rules/coordinator.py
@@ -134,7 +134,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
         domain, name = service.split(".", 1) if "." in service else ("notify", service)
         if not self.hass.services.has_service(domain, name): self._create_issue(c.ISSUE_NOTIFICATION_SERVICE, {"service": service}); return
         self._clear_issue(c.ISSUE_NOTIFICATION_SERVICE)
-        _emoji = {"Cool": "❄️", "Dry": "💧", "Off": "⏹", "Timer": "⏱", "Disabled": "⏸", "Reset": "🔄"}
+        _emoji = {"Cool": "❄️", "Dry": "💧", "Off": "⏹", "On": "🔛", "Timer": "⏱", "Disabled": "⏸", "Reset": "🔄"}
         new = (self._session.last or current).value; icon = _emoji.get(new, "")
         try: await self.hass.services.async_call(domain, name, {"title": f"{icon} Aircon → {new}", "message": f"Switched from {previous.value} to {new}"}, blocking=False)
         except ServiceValidationError: self._create_issue(c.ISSUE_NOTIFICATION_SERVICE, {"service": service})
@@ -177,6 +177,7 @@ class HomeRulesCoordinator(DataUpdateCoordinator[CoordinatorData]):
         solar_unknown = inverter_online and not gen_live  # inverter claims online but no telemetry, so solar cannot be confirmed (vs offline = confirmed no solar)
         mode = AirconMode.UNKNOWN
         with suppress(ValueError): mode = AirconMode(str(climate.state).lower().strip())
+        if mode not in (AirconMode.COOL, AirconMode.DRY): self._auto_mode = False  # self-heal: only COOL/DRY are home-rules-owned runs; a user-switched mode is external
         aggressive = self.control_mode is c.ControlMode.BOOST_COOLING; enabled = self.control_mode is not c.ControlMode.DISABLED
         return HomeInput(mode, have_solar, generation, grid_usage, timer is not None, self._normalized_temperature(temp), self._state_to_float(hum, "humidity"), self._auto_mode, aggressive, enabled, self.cooling_enabled, solar_unknown), timer
 

--- a/custom_components/home_rules/rules.py
+++ b/custom_components/home_rules/rules.py
@@ -61,6 +61,7 @@ class AirconMode(StrEnum):
 class HomeOutput(StrEnum):
     NO_CHANGE = "No Change"
     OFF = "Off"
+    ON = "On"
     COOL = "Cool"
     DRY = "Dry"
     TIMER = "Timer"
@@ -172,7 +173,7 @@ def current_state(home: HomeInput) -> HomeOutput:
         return HomeOutput.TIMER
     return {AirconMode.COOL: HomeOutput.COOL, AirconMode.DRY: HomeOutput.DRY}.get(
         home.aircon_mode,
-        HomeOutput.OFF if home.aircon_mode in (AirconMode.OFF, AirconMode.UNKNOWN) else HomeOutput.COOL,
+        HomeOutput.OFF if home.aircon_mode in (AirconMode.OFF, AirconMode.UNKNOWN) else HomeOutput.ON,
     )
 
 
@@ -225,7 +226,17 @@ def adjust(config: RuleParameters, home: HomeInput, state: CachedState) -> Adjus
             return AdjustResult(HomeOutput.RESET, R_TIMER_EXPIRED)
         return AdjustResult(HomeOutput.NO_CHANGE, _idle_reason(config, h, activation, R_NO_CHANGE))
 
-    # --- Aircon is ON + grid draw (or no solar) ---
+    # --- Aircon is ON in a mode home-rules never commands (heat/heat_cool/fan_only/auto) ---
+    # Such a run is external by definition: cap it and turn it off at expiry, independent of
+    # solar. Only COOL/DRY runs follow the solar economics below.
+    if h.aircon_mode not in (AirconMode.COOL, AirconMode.DRY):
+        if h.timer:
+            return AdjustResult(HomeOutput.NO_CHANGE, R_NO_CHANGE)
+        if state.last is HomeOutput.TIMER:
+            return AdjustResult(HomeOutput.OFF, R_TIMER_EXPIRED)
+        return AdjustResult(HomeOutput.TIMER, R_MANUAL)
+
+    # --- Cooling run + grid draw (or no solar) ---
     if not h.have_solar or h.grid_usage > 0:
         if h.auto:
             # If a mode transition is available (e.g. COOL→DRY downgrade), apply immediately.
@@ -258,14 +269,14 @@ def adjust(config: RuleParameters, home: HomeInput, state: CachedState) -> Adjus
             return AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
         return AdjustResult(OUT.TIMER, R_MANUAL)
 
-    # --- Aircon is ON + free solar ---
+    # --- Cooling run + free solar ---
     if h.auto:
         state.tolerated = 0
         if target.output is not None:
             return AdjustResult(target.output, target.reason)
         return AdjustResult(HomeOutput.NO_CHANGE, activation or R_NO_CHANGE)
 
-    # Manual run confirmed on genuine free solar: clear a now-stale expired cap.
+    # Manual cooling run confirmed on genuine free solar: clear a now-stale expired cap.
     if state.last is HomeOutput.TIMER and not h.timer:
         return AdjustResult(HomeOutput.RESET, R_TIMER_EXPIRED)
     return AdjustResult(HomeOutput.NO_CHANGE, R_NO_CHANGE)

--- a/tests/test_coordinator_hvac_mode.py
+++ b/tests/test_coordinator_hvac_mode.py
@@ -36,3 +36,28 @@ async def test_execute_adjustment_sets_explicit_hvac_mode(hass, coord_factory) -
             {"entity_id": "climate.test", "temperature": coordinator.parameters.temperature_cool},
         ),
     ]
+
+
+async def test_stale_auto_mode_self_heals_for_heat(hass, coord_factory) -> None:
+    """A stale auto=True (home-rules ran cool, user then switched to HEAT) self-heals to
+    auto=False and starts a manual cap instead of flipping the unit back to COOL."""
+    from custom_components.home_rules.const import ControlMode
+    from custom_components.home_rules.rules import HomeOutput
+
+    commanded: list[str] = []
+
+    async def record(call) -> None:
+        commanded.append(call.data.get("hvac_mode", call.service))
+
+    hass.services.async_register("climate", "set_hvac_mode", record)
+    hass.services.async_register("climate", "set_temperature", record)
+    hass.services.async_register("climate", "turn_off", record)
+
+    # Strong free solar + heat: the old engine would have commanded COOL.
+    coordinator = await coord_factory(climate="heat", generation="6000", grid="0")
+    coordinator._auto_mode = True  # simulate a prior cool cycle that home-rules owned
+    await coordinator.async_set_mode(ControlMode.SOLAR_COOLING)
+
+    assert coordinator._auto_mode is False  # self-healed: heat is never home-rules-owned
+    assert coordinator.data.adjustment is HomeOutput.TIMER  # capped, not cooled
+    assert "cool" not in commanded  # never issued set_hvac_mode: cool on a heat run

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -241,17 +241,17 @@ class TestCurrentState:
     def test_unknown(self):
         assert current_state(home(aircon_mode=AirconMode.UNKNOWN)) is OUT.OFF
 
-    def test_fan_only_fallback_to_cool(self):
-        assert current_state(home(aircon_mode=AirconMode.FAN_ONLY)) is OUT.COOL
+    def test_fan_only_maps_to_on(self):
+        assert current_state(home(aircon_mode=AirconMode.FAN_ONLY)) is OUT.ON
 
-    def test_heat_fallback_to_cool(self):
-        assert current_state(home(aircon_mode=AirconMode.HEAT)) is OUT.COOL
+    def test_heat_maps_to_on(self):
+        assert current_state(home(aircon_mode=AirconMode.HEAT)) is OUT.ON
 
-    def test_heat_cool_fallback_to_cool(self):
-        assert current_state(home(aircon_mode=AirconMode.HEAT_COOL)) is OUT.COOL
+    def test_heat_cool_maps_to_on(self):
+        assert current_state(home(aircon_mode=AirconMode.HEAT_COOL)) is OUT.ON
 
-    def test_auto_fallback_to_cool(self):
-        assert current_state(home(aircon_mode=AirconMode.AUTO)) is OUT.COOL
+    def test_auto_maps_to_on(self):
+        assert current_state(home(aircon_mode=AirconMode.AUTO)) is OUT.ON
 
 
 # ---------------------------------------------------------------------------
@@ -1513,3 +1513,78 @@ class TestManualOvernightCapLifecycle:
             state,
         )
         assert expired == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+
+
+class TestManualHeatFreeSolarCap:
+    """Incident regression: a heat run on FREE solar must still be capped and turned OFF.
+
+    Before the mode-aware fix, a heat run on free solar was never capped (start) and its
+    expired cap was cleared with RESET (kept running), so the heater ran all day.
+    """
+
+    def _heat(self, **kw) -> HomeInput:
+        base = dict(aircon_mode=AirconMode.HEAT, have_solar=True, generation=2016.0, grid_usage=0.0, auto=False)
+        base.update(kw)
+        return home(**base)
+
+    def test_free_solar_heat_starts_cap(self):
+        """Defect A: manual heat on free solar arms the cap (previously NO_CHANGE)."""
+        r = adjust(TEST_PARAMS, self._heat(timer=False), CachedState(last=OUT.OFF))
+        assert r == AdjustResult(OUT.TIMER, R_MANUAL)
+
+    def test_free_solar_heat_holds_while_capped(self):
+        r = adjust(TEST_PARAMS, self._heat(timer=True), CachedState(last=OUT.TIMER))
+        assert r == AdjustResult(OUT.NO_CHANGE, R_NO_CHANGE)
+
+    def test_free_solar_heat_expiry_turns_off(self):
+        """The incident: expired cap on free solar turns OFF (previously RESET/keep-running)."""
+        r = adjust(TEST_PARAMS, self._heat(timer=False), CachedState(last=OUT.TIMER))
+        assert r == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+
+    def test_grid_heat_expiry_still_turns_off(self):
+        """No regression: expiry on grid draw still turns OFF."""
+        r = adjust(TEST_PARAMS, self._heat(grid_usage=300.0, timer=False), CachedState(last=OUT.TIMER))
+        assert r == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+
+    def test_lifecycle_arm_hold_expire_off_rearm(self):
+        """Full user story on free solar: arm -> hold -> expire OFF -> manual on again -> re-arm."""
+        state = CachedState(last=OUT.OFF)
+        assert adjust(TEST_PARAMS, self._heat(timer=False), state) == AdjustResult(OUT.TIMER, R_MANUAL)
+        apply_adjustment(state, OUT.ON, OUT.TIMER)  # session.last -> TIMER
+        assert adjust(TEST_PARAMS, self._heat(timer=True), state) == AdjustResult(OUT.NO_CHANGE, R_NO_CHANGE)
+        assert adjust(TEST_PARAMS, self._heat(timer=False), state) == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+        apply_adjustment(state, OUT.ON, OUT.OFF)  # session.last -> OFF
+        assert adjust(TEST_PARAMS, self._heat(timer=False), state) == AdjustResult(OUT.TIMER, R_MANUAL)
+
+    def test_recorded_free_solar_expiries_turn_off(self):
+        """Real generation readings recorded at the free-solar cap expiries (grid=0)."""
+        for generation in (2016.0, 5596.0, 1210.0):
+            r = adjust(
+                TEST_PARAMS,
+                self._heat(generation=generation, timer=False),
+                CachedState(last=OUT.TIMER),
+            )
+            assert r == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+
+
+class TestStaleAutoHeat:
+    """A stale auto=True (home-rules ran cool, user switched to heat) must not keep a heat run
+    alive or flip it back to COOL. The mode-first branch treats any non-cool run as external."""
+
+    def test_stale_auto_heat_expiry_turns_off(self):
+        r = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.HEAT, have_solar=True, generation=2016.0, grid_usage=0.0, auto=True),
+            CachedState(last=OUT.TIMER),
+        )
+        assert r == AdjustResult(OUT.OFF, R_TIMER_EXPIRED)
+
+    def test_stale_auto_heat_strong_sun_never_flips_to_cool(self):
+        """Generation above the cool threshold must not command COOL on a heat run."""
+        r = adjust(
+            TEST_PARAMS,
+            home(aircon_mode=AirconMode.HEAT, have_solar=True, generation=6000.0, grid_usage=0.0, auto=True),
+            CachedState(last=OUT.OFF),
+        )
+        assert r.output is OUT.TIMER
+        assert r.output is not OUT.COOL


### PR DESCRIPTION
## What went wrong

On a winter morning the aircon was run in **heat** while home-rules was in `solar_cooling` mode. home-rules only turned an externally started run off at cap expiry when the house was drawing from the grid. Every midday cap expiry landed on **free solar** (grid draw zero), where the engine issued `RESET` and kept the run alive, relabelling it "Cool". The heater never switched off and oscillated `Timer` to `Cool` all day.

The user's intended behaviour is simple: any run home-rules did not start gets a one-hour cap, then the unit turns off, for heat as well as cool. Steps one to three worked in the morning; step four failed at the first free-solar expiry.

## Root cause

In `rules.py::adjust()` the manual-run cap was entangled with solar cooling economics:

- the cap only **started** in the grid-draw branch, so a run begun on free solar was never capped, and
- an expired cap on free solar returned `RESET` (keep running) instead of `OFF`.

That logic suits solar cooling ("if the sun is paying, let a manual cool run ride"), but it is wrong for a universal auto-off and doubly wrong for heat, which the engine did not model at all (`current_state()` mapped `heat` to the `Cool` label).

## The fix

- **Mode-aware cap.** Branch the aircon-on handling on ownership: a run in a mode home-rules never commands (`heat`, `heat_cool`, `fan_only`, `auto`) is external, so it is capped and turned off at expiry independent of solar. `COOL` and `DRY` keep the existing solar economics and free-solar ride, so summer cooling is unchanged.
- **Auto-flag self-heal.** `_build_home_input` clears the owned-run flag whenever the live mode is not `COOL` or `DRY`, so a user switch from cool to heat can no longer be read as an owned run (which could otherwise flip the unit back to cool on strong sun).
- **Honest label.** Non-cooling runs report a new `On` state instead of masquerading as `Cool`.

## Proof against the real incident

Replaying the exact recorded inputs through the engine before and after:

| Scenario | Before | After |
|---|---|---|
| Incident free-solar heat expiry | `Reset` (keeps running) | `Off` |
| Free-solar heat start | `No Change` (never caps) | `Timer` |
| Stale auto + heat | `No Change` (runs forever) | `Off` |
| Stale auto + strong sun | `Cool` (flips heat to cool) | `Off` |
| Grid expiry / cool free-solar ride | correct | unchanged |

## Tests

- Added `TestManualHeatFreeSolarCap` (start, hold, expiry, grid expiry, full lifecycle, recorded-input replay) and `TestStaleAutoHeat`, plus a coordinator self-heal test.
- Updated `TestCurrentState` for the honest `On` label.
- Full suite: 209 passing, `rules.py` at 100 percent coverage, lint, format and mypy clean.